### PR TITLE
add magic link login, token, and logout pages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,6 @@ jobs:
           rebar3-version: "3"
           # elixir-version: "1"
       - run: gleam deps download
+      - run: gleam run -m squirrel
       - run: gleam test
       - run: gleam format --check src test

--- a/gleam.toml
+++ b/gleam.toml
@@ -28,6 +28,8 @@ zeptomail = { path = "../../zeptomail" }
 gleam_httpc = ">= 4.1.0 and < 5.0.0"
 gleam_yielder = ">= 1.1.0 and < 2.0.0"
 gleam_crypto = ">= 1.5.0 and < 2.0.0"
+youid = ">= 1.4.0 and < 2.0.0"
+valid = ">= 4.5.0 and < 5.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -30,6 +30,7 @@ gleam_yielder = ">= 1.1.0 and < 2.0.0"
 gleam_crypto = ">= 1.5.0 and < 2.0.0"
 youid = ">= 1.4.0 and < 2.0.0"
 valid = ">= 4.5.0 and < 5.0.0"
+snag = ">= 1.1.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -53,6 +53,7 @@ packages = [
   { name = "pog", version = "3.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "pgo"], otp_app = "pog", source = "hex", outer_checksum = "63152DADEBAE3150C81E9612909974C3C38F3E35B41F252798069A2FD117308E" },
   { name = "shellout", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "shellout", source = "hex", outer_checksum = "1BDC03438FEB97A6AF3E396F4ABEB32BECF20DF2452EC9A8C0ACEB7BDDF70B14" },
   { name = "simplifile", version = "2.2.1", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "C88E0EE2D509F6D86EB55161D631657675AA7684DAB83822F7E59EB93D9A60E3" },
+  { name = "snag", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "7E9F06390040EB5FAB392CE642771484136F2EC103A92AE11BA898C8167E6E17" },
   { name = "squirrel", version = "3.0.3", build_tools = ["gleam"], requirements = ["argv", "envoy", "eval", "filepath", "glam", "gleam_community_ansi", "gleam_crypto", "gleam_json", "gleam_regexp", "gleam_stdlib", "glexer", "justin", "mug", "non_empty_list", "pog", "simplifile", "term_size", "tom", "tote", "youid"], otp_app = "squirrel", source = "hex", outer_checksum = "09C0B65609E15FFE2D08BE5DED392B1D48557136097FD415229A8FB298247850" },
   { name = "ssl_verify_fun", version = "1.1.7", build_tools = ["mix", "rebar3", "make"], requirements = [], otp_app = "ssl_verify_fun", source = "hex", outer_checksum = "FE4C190E8F37401D30167C8C405EDA19469F34577987C76DDE613E838BBC67F8" },
   { name = "telemetry", version = "1.3.0", build_tools = ["rebar3"], requirements = [], otp_app = "telemetry", source = "hex", outer_checksum = "7015FC8919DBE63764F4B4B87A95B7C0996BD539E0D499BE6EC9D7F3875B79E6" },
@@ -82,6 +83,7 @@ glotel = { version = ">= 0.1.0 and < 1.0.0" }
 lustre = { version = ">= 5.0.2 and < 6.0.0" }
 mist = { version = ">= 4.0.7 and < 5.0.0" }
 pog = { version = ">= 3.2.0 and < 4.0.0" }
+snag = { version = ">= 1.1.0 and < 2.0.0" }
 squirrel = { version = ">= 3.0.3 and < 4.0.0" }
 valid = { version = ">= 4.5.0 and < 5.0.0" }
 wisp = { version = ">= 1.6.0 and < 2.0.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -61,6 +61,7 @@ packages = [
   { name = "tom", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tom", source = "hex", outer_checksum = "0910EE688A713994515ACAF1F486A4F05752E585B9E3209D8F35A85B234C2719" },
   { name = "tote", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "tote", source = "hex", outer_checksum = "A249892E26A53C668897F8D47845B0007EEE07707A1A03437487F0CD5A452CA5" },
   { name = "ts_chatterbox", version = "0.15.1", build_tools = ["rebar3"], requirements = ["hpack_erl"], otp_app = "chatterbox", source = "hex", outer_checksum = "4F75B91451338BC0DA5F52F3480FA6EF6E3A2AEECFC33686D6B3D0A0948F31AA" },
+  { name = "valid", version = "4.5.0", build_tools = ["gleam"], requirements = ["gleam_regexp", "gleam_stdlib", "non_empty_list"], otp_app = "valid", source = "hex", outer_checksum = "510EEF581F86EFA7D7364AFC41E36241411009B2434EC5ABC7A72CBC0AB5281A" },
   { name = "wisp", version = "1.6.0", build_tools = ["gleam"], requirements = ["directories", "exception", "gleam_crypto", "gleam_erlang", "gleam_http", "gleam_json", "gleam_stdlib", "logging", "marceau", "mist", "simplifile"], otp_app = "wisp", source = "hex", outer_checksum = "AE1C568FE30718C358D3B37666DF0A0743ECD96094AD98C9F4921475075F660A" },
   { name = "youid", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_crypto", "gleam_erlang", "gleam_stdlib"], otp_app = "youid", source = "hex", outer_checksum = "DFC3718B6BFAD7FED4303C0DDEC3275D501466CF100E556936284F72B1723968" },
   { name = "zeptomail", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_http", "gleam_json", "gleam_stdlib"], source = "local", path = "../../zeptomail" },
@@ -82,5 +83,7 @@ lustre = { version = ">= 5.0.2 and < 6.0.0" }
 mist = { version = ">= 4.0.7 and < 5.0.0" }
 pog = { version = ">= 3.2.0 and < 4.0.0" }
 squirrel = { version = ">= 3.0.3 and < 4.0.0" }
+valid = { version = ">= 4.5.0 and < 5.0.0" }
 wisp = { version = ">= 1.6.0 and < 2.0.0" }
+youid = { version = ">= 1.4.0 and < 2.0.0" }
 zeptomail = { path = "../../zeptomail" }

--- a/priv/migrations/20250424044625-initial_schema.sql
+++ b/priv/migrations/20250424044625-initial_schema.sql
@@ -6,30 +6,23 @@ begin
 end;
 $$ language plpgsql;
 
-create function set_created_at() returns trigger as $$
-begin
-  new.created_at = now();
-  return new;
-end;
-$$ language plpgsql;
 
 create table users(
-  id uuid primary key,
+  id uuid primary key default gen_random_uuid(),
   email varchar(255) not null,
   name varchar(255) not null,
-  created_at timestamp not null,
-  updated_at timestamp not null,
+  created_at timestamp not null default now(),
+  updated_at timestamp not null default now(),
   deleted_at timestamp,
   unique (email)
 );
 
 create trigger users_updated_at before update on users for each row execute procedure set_updated_at();
-create trigger users_created_at before insert on users for each row execute procedure set_created_at();
 
 create index users_email_index on users(email);
 
 create table events(
-  id uuid primary key,
+  id uuid primary key default gen_random_uuid(),
   slug varchar(255) not null,
   name varchar(255) not null,
   description text not null,
@@ -37,62 +30,58 @@ create table events(
   start_date timestamp not null,
   end_date timestamp,
   location varchar(255) not null,
-  created_at timestamp not null,
-  updated_at timestamp not null,
+  created_at timestamp not null default now(),
+  updated_at timestamp not null default now(),
   deleted_at timestamp
 );
 
 create trigger events_updated_at before update on events for each row execute procedure set_updated_at();
-create trigger events_created_at before insert on events for each row execute procedure set_created_at();
 
 create index events_slug_index on events(slug);
 
 create table hosts(
   event_id uuid references events(id) on delete cascade,
   user_id uuid references users(id) on delete cascade,
-  created_at timestamp not null,
-  updated_at timestamp not null,
+  created_at timestamp not null default now(),
+  updated_at timestamp not null default now(),
   deleted_at timestamp,
   primary key (event_id, user_id)
 );
 
 create trigger hosts_updated_at before update on hosts for each row execute procedure set_updated_at();
-create trigger hosts_created_at before insert on hosts for each row execute procedure set_created_at();
 
 create index hosts_event_id_index on hosts(event_id);
 
 create table host_invites(
-  id uuid primary key,
+  id uuid primary key default gen_random_uuid(),
   event_id uuid references events(id) on delete cascade,
   user_id uuid references users(id) on delete cascade,
   invite_code varchar(255) not null,
   note varchar(255),
-  created_at timestamp not null,
-  updated_at timestamp not null,
+  created_at timestamp not null default now(),
+  updated_at timestamp not null default now(),
   deleted_at timestamp,
   unique (event_id, invite_code)
 );
 
 create trigger host_invites_updated_at before update on host_invites for each row execute procedure set_updated_at();
-create trigger host_invites_created_at before insert on host_invites for each row execute procedure set_created_at();
 
 create index host_invites_event_id_index on host_invites(event_id);
 create index host_invites_invite_code_index on host_invites(invite_code);
 
 create table responses(
-  id uuid primary key,
+  id uuid primary key default gen_random_uuid(),
   event_id uuid references events(id) on delete cascade,
   user_id uuid references users(id) on delete cascade,
   guests integer not null constraint positive_guests check (guests > 0),
   message text,
-  created_at timestamp not null,
-  updated_at timestamp not null,
+  created_at timestamp not null default now(),
+  updated_at timestamp not null default now(),
   deleted_at timestamp,
   unique (event_id, user_id)
 );
 
 create trigger responses_updated_at before update on responses for each row execute procedure set_updated_at();
-create trigger responses_created_at before insert on responses for each row execute procedure set_created_at();
 
 create index responses_event_id_index on responses(event_id);
 create index responses_user_id_index on responses(user_id);
@@ -125,7 +114,6 @@ drop trigger users_created_at on users;
 drop trigger users_updated_at on users;
 drop table users;
 
-drop function set_created_at();
 drop function set_updated_at();
 
 --- migration:end

--- a/priv/migrations/20250425054002-add_users_tokens.sql
+++ b/priv/migrations/20250425054002-add_users_tokens.sql
@@ -1,16 +1,14 @@
 --- migration:up
 
 create table users_tokens(
-  id uuid primary key,
+  id uuid primary key default gen_random_uuid(),
   user_id uuid references users(id) on delete cascade,
   token bytea not null,
   context varchar(255) not null,
   sent_to varchar(255) not null,
-  created_at timestamp not null,
+  created_at timestamp not null default now(),
   unique (user_id, token)
 );
-
-create trigger users_tokens_created_at before insert on users_tokens for each row execute procedure set_created_at();
 
 create index users_tokens_user_id_index on users_tokens(user_id);
 

--- a/src/js/icons.js
+++ b/src/js/icons.js
@@ -1,10 +1,13 @@
-import { LogIn } from "lucide";
+import { LoaderCircle, LogIn, Mail, Send } from "lucide";
 import replaceElement from "lucide/dist/esm/replaceElement.js";
 
 // this is the same as the typical lucide config ...
 const config = {
     icons: {
+        LoaderCircle,
         LogIn,
+        Mail,
+        Send,
         // any other icons you want to use here
     },
     // ... except that this is required as we are skipping the function which 

--- a/src/rsvp.gleam
+++ b/src/rsvp.gleam
@@ -1,6 +1,7 @@
 import cigogne
 import dotenv_gleam
 import gleam/erlang/process
+import gleam/option
 import gleam/result
 import mist
 import rsvp/config
@@ -19,7 +20,12 @@ pub fn main() {
   let assert Ok(priv) = wisp.priv_directory("rsvp")
   let assert Ok(db_connection) = database.db_connect()
   let context =
-    Context(db: db_connection, nonce: "", static_path: priv <> "/static")
+    Context(
+      db: db_connection,
+      nonce: "",
+      static_path: priv <> "/static",
+      user: option.None,
+    )
 
   // migrate db if necessary
   cigogne.execute_migrations_to_last(db_connection)

--- a/src/rsvp/context.gleam
+++ b/src/rsvp/context.gleam
@@ -1,5 +1,12 @@
+import gleam/option.{type Option}
 import pog.{type Connection}
+import rsvp/models/users.{type User}
 
 pub type Context {
-  Context(db: Connection, nonce: String, static_path: String)
+  Context(
+    db: Connection,
+    nonce: String,
+    static_path: String,
+    user: Option(User),
+  )
 }

--- a/src/rsvp/database.gleam
+++ b/src/rsvp/database.gleam
@@ -12,7 +12,11 @@ pub fn db_connect() -> Result(pog.Connection, Nil) {
   }
 
   use db_config <- result.try(pog.url_config(db_url))
-  Ok(pog.connect(db_config))
+
+  db_config
+  |> pog.trace(True)
+  |> pog.connect()
+  |> Ok
 }
 
 /// Ensures the DB is created. I do this because it is really handy to be able

--- a/src/rsvp/email.gleam
+++ b/src/rsvp/email.gleam
@@ -1,4 +1,5 @@
 import gleam/httpc
+import gleam/uri
 import rsvp/config
 import wisp
 import zeptomail.{Addressee}
@@ -37,7 +38,7 @@ pub fn send_email(
 
 const auth_email = "auth@mail.wallw.dev"
 
-pub fn send_magic_link_email(address: String, token: String) {
+pub fn send_token_email(address: String, token: String, redirect: String) {
   let app_name = config.app_name()
   let base_url = config.base_url()
 
@@ -49,8 +50,10 @@ pub fn send_magic_link_email(address: String, token: String) {
     <> app_name
     <> "\n\n"
     <> base_url
-    <> "/login/"
+    <> "/token/"
     <> token
+    <> "?"
+    <> uri.query_to_string([#("r", redirect)])
     <> "\n\nIf you did not request this email, you can safely ignore it."
 
   send_email(

--- a/src/rsvp/email.gleam
+++ b/src/rsvp/email.gleam
@@ -1,6 +1,7 @@
 import gleam/httpc
 import gleam/uri
 import rsvp/config
+import snag
 import wisp
 import zeptomail.{Addressee}
 
@@ -80,23 +81,13 @@ fn send_over_api(email: zeptomail.Email) {
 
       case decoded {
         Ok(_) -> Ok(Nil)
-
-        Error(zeptomail.ApiError(code, message, _details)) -> {
-          wisp.log_error("Error sending email: " <> code <> " " <> message)
-          Error(Nil)
-        }
-
-        Error(zeptomail.UnexpectedResponse(_)) -> {
-          wisp.log_error("Error decoding email result json.")
-          Error(Nil)
-        }
+        Error(zeptomail.ApiError(code, message, _details)) ->
+          snag.error("Error sending email: " <> code <> " " <> message)
+        Error(zeptomail.UnexpectedResponse(_)) ->
+          snag.error("Error decoding email result json")
       }
     }
 
-    Error(err) -> {
-      echo err
-      wisp.log_error("http error sending email")
-      Error(Nil)
-    }
+    Error(_err) -> snag.error("http error sending email")
   }
 }

--- a/src/rsvp/htmx.gleam
+++ b/src/rsvp/htmx.gleam
@@ -1,0 +1,60 @@
+import gleam/bool
+import gleam/http/request
+import gleam/result
+import gleam/string
+import lustre/attribute
+import wisp.{type Request, type Response}
+
+/// sets the hx-post attribute
+pub fn hx_post(url: String) {
+  attribute.attribute("hx-post", url)
+}
+
+/// sets the hx-swap attribute
+pub fn hx_swap(swap: String) {
+  attribute.attribute("hx-swap", swap)
+}
+
+/// sets the hx-target attribute
+pub fn hx_target(target: String) {
+  attribute.attribute("hx-target", target)
+}
+
+/// If the request is an HTMX request, uses the `HX-Location` response header to
+/// redirect the client via hx-boost.
+///
+/// Otherwise, sends a standard http redirect
+pub fn redirect(redirect: String, req: Request) {
+  case is_htmx_request(req) {
+    True ->
+      wisp.response(200)
+      |> location(redirect)
+
+    False -> wisp.redirect(redirect)
+  }
+}
+
+pub fn location(response: Response, location: String) {
+  wisp.set_header(response, "hx-location", location)
+}
+
+pub fn reswap(response: Response, value: String) {
+  wisp.set_header(response, "hx-reswap", value)
+}
+
+pub fn retarget(response: Response, value: String) {
+  wisp.set_header(response, "hx-retarget", value)
+}
+
+pub fn push_url(response: Response, value: String) {
+  wisp.set_header(response, "hx-push-url", value)
+}
+
+/// whether or not the request is from HTMX
+pub fn is_htmx_request(req: Request) {
+  req
+  |> request.get_header("hx-current-url")
+  |> result.unwrap("")
+  |> string.is_empty()
+  |> bool.negate
+}

--- a/src/rsvp/layouts.gleam
+++ b/src/rsvp/layouts.gleam
@@ -1,3 +1,4 @@
+import gleam/option.{None, Some}
 import lustre/attribute
 import lustre/element
 import lustre/element/html
@@ -39,7 +40,11 @@ pub fn root_layout(
   ])
 }
 
-pub fn nav_layout(content: List(element.Element(a)), req: Request, ctx: Context) {
+pub fn nav_layout(
+  content: List(element.Element(a)),
+  _req: Request,
+  ctx: Context,
+) {
   [
     html.header([attribute.class("container")], [
       html.nav([], [
@@ -48,14 +53,25 @@ pub fn nav_layout(content: List(element.Element(a)), req: Request, ctx: Context)
             html.a([attribute.href("/")], [html.strong([], [html.text("RSVP")])]),
           ]),
         ]),
-        html.ul([], [
-          html.li([], [
-            html.a([attribute.href("/login")], [
-              core.icon("log-in", []),
-              html.text(" Login"),
+        html.ul([], case ctx.user {
+          Some(_user) -> [
+            html.li([], [
+              html.a([attribute.href("/events")], [html.text("Events")]),
             ]),
-          ]),
-        ]),
+            html.li([], [
+              html.a([attribute.href("/logout")], [html.text("Logout")]),
+            ]),
+          ]
+
+          None -> [
+            html.li([], [
+              html.a([attribute.href("/login")], [
+                core.icon("log-in", []),
+                html.text(" Login"),
+              ]),
+            ]),
+          ]
+        }),
       ]),
     ]),
     html.main([attribute.class("container")], content),
@@ -63,10 +79,14 @@ pub fn nav_layout(content: List(element.Element(a)), req: Request, ctx: Context)
 }
 
 pub fn to_html_response(content: element.Element(a)) {
-  wisp.response(200)
+  to_html_status(content, 200)
+}
+
+pub fn to_html_status(content: element.Element(a), status: Int) {
+  wisp.response(status)
   |> wisp.set_header("Content-Type", "text/html")
-  |> wisp.html_body(
+  |> wisp.string_body(
     content
-    |> element.to_document_string_tree(),
+    |> element.to_string(),
   )
 }

--- a/src/rsvp/models/auth.gleam
+++ b/src/rsvp/models/auth.gleam
@@ -3,34 +3,32 @@ import pog
 import rsvp/email
 import rsvp/models/tokens
 import rsvp/models/users
-import wisp
+import snag
 
 pub fn email_user_with_magic_link(
   db: pog.Connection,
   email: String,
   redirect: String,
 ) {
-  let user =
+  use user <- result.try(
     db
     |> users.get_user_by_email(email)
     |> result.try_recover(fn(_) { users.create_user(db, email, "") })
+    |> snag.context("Could not get or create user"),
+  )
 
-  case user {
-    Ok(user) -> {
-      let #(email_token, token) = tokens.build_email_token(user, "login")
+  let #(to_email, token) = tokens.build_email_token(user, "login")
 
-      db
-      |> tokens.create_token(token)
-      |> result.map_error(fn(_) { Nil })
-      |> result.map(fn(_) {
-        email.send_token_email(email, email_token, redirect)
-      })
-    }
+  use _created_token <- result.try(
+    db
+    |> tokens.create_token(token)
+    |> snag.context("could not create token"),
+  )
 
-    err -> {
-      echo err
-      wisp.log_error("could not get or create user")
-      Error(Nil)
-    }
-  }
+  use email_result <- result.try(
+    email.send_token_email(email, to_email, redirect)
+    |> snag.context("Could not send token email"),
+  )
+
+  Ok(email_result)
 }

--- a/src/rsvp/models/auth.gleam
+++ b/src/rsvp/models/auth.gleam
@@ -1,0 +1,36 @@
+import gleam/result
+import pog
+import rsvp/email
+import rsvp/models/tokens
+import rsvp/models/users
+import wisp
+
+pub fn email_user_with_magic_link(
+  db: pog.Connection,
+  email: String,
+  redirect: String,
+) {
+  let user =
+    db
+    |> users.get_user_by_email(email)
+    |> result.try_recover(fn(_) { users.create_user(db, email, "") })
+
+  case user {
+    Ok(user) -> {
+      let #(email_token, token) = tokens.build_email_token(user, "login")
+
+      db
+      |> tokens.create_token(token)
+      |> result.map_error(fn(_) { Nil })
+      |> result.map(fn(_) {
+        email.send_token_email(email, email_token, redirect)
+      })
+    }
+
+    err -> {
+      echo err
+      wisp.log_error("could not get or create user")
+      Error(Nil)
+    }
+  }
+}

--- a/src/rsvp/models/id.gleam
+++ b/src/rsvp/models/id.gleam
@@ -1,0 +1,20 @@
+import gleam/result
+import youid/uuid
+
+pub type Id(a) {
+  Id(String)
+}
+
+pub fn from_uuid(value) {
+  value
+  |> uuid.to_string()
+  |> Id()
+}
+
+pub fn to_uuid(value: Id(_)) {
+  let Id(str) = value
+
+  str
+  |> uuid.from_string()
+  |> result.unwrap(uuid.v4())
+}

--- a/src/rsvp/models/id.gleam
+++ b/src/rsvp/models/id.gleam
@@ -18,3 +18,8 @@ pub fn to_uuid(value: Id(_)) {
   |> uuid.from_string()
   |> result.unwrap(uuid.v4())
 }
+
+pub fn to_string(value: Id(_)) {
+  let Id(str) = value
+  str
+}

--- a/src/rsvp/models/pog_utils.gleam
+++ b/src/rsvp/models/pog_utils.gleam
@@ -1,0 +1,53 @@
+import gleam/int
+import gleam/string
+import pog
+import snag
+
+pub fn pog_error_to_snag(error: pog.QueryError, layer: String) {
+  error
+  |> map_pog_error()
+  |> snag.new()
+  |> snag.layer(layer)
+  |> Error()
+}
+
+// For what it's worth, I don't really like having to do this, despite how most
+// of it is covered by the compiler (if the underlying library swaps the order of 
+// string args we might be fucked though).
+//
+// I'd rather just be able to stringify anything like you can with `echo error`,
+// however, I understand why that is difficult outside of dev (effectively the 
+// types don't really exist after compilation; at least that's my understanding
+// considering it compiles to Erlang).
+//
+// Another potential gripe: the pog lib should probably be responsible for providing 
+// at least basic to_string functions for its types.
+fn map_pog_error(error: pog.QueryError) {
+  case error {
+    pog.ConstraintViolated(message, constraint, detail) -> [
+      message,
+      constraint,
+      detail,
+    ]
+
+    pog.PostgresqlError(code, name, message) -> [code, name, message]
+
+    pog.UnexpectedArgumentCount(expected, got) -> [
+      "Unexpected argument count. Expected "
+      <> int.to_string(expected)
+      <> " got "
+      <> int.to_string(got),
+    ]
+
+    pog.UnexpectedArgumentType(expected, got) -> [
+      "Unexpected argument type. Expected " <> expected <> " got " <> got,
+    ]
+
+    pog.UnexpectedResultType(_) -> ["Unexpected result type. Could not decode."]
+
+    pog.QueryTimeout -> ["Query timeout"]
+
+    pog.ConnectionUnavailable -> ["Connection unavailable"]
+  }
+  |> string.join(": ")
+}

--- a/src/rsvp/models/tokens.gleam
+++ b/src/rsvp/models/tokens.gleam
@@ -1,0 +1,168 @@
+//// Handles user tokens for various reasons
+//// If this looks like it was translated from phoenix's `user_token.ex`, it was
+
+import gleam/bit_array
+import gleam/crypto
+import gleam/option.{type Option, None, Some}
+import gleam/result
+import pog
+import rsvp/models/id.{type Id, Id}
+import rsvp/models/tokens/sql
+import rsvp/models/users.{type User, User}
+
+const rand_size = 32
+
+pub type Token {
+  Token(
+    user_id: Id(User),
+    token: BitArray,
+    context: String,
+    sent_to: Option(String),
+  )
+}
+
+pub type TokenError {
+  CreateTokenError
+  SessionVerifyError
+  EmailVerifyError
+  EmailDecodeError
+  MissingUUIDError
+}
+
+pub fn create_token(db: pog.Connection, token: Token) {
+  let query =
+    sql.create_token(
+      db,
+      token.user_id |> id.to_uuid(),
+      token.token,
+      token.context,
+      token.sent_to |> option.unwrap(""),
+    )
+
+  case query {
+    Ok(pog.Returned(1, [token_row])) ->
+      Ok(Token(
+        user_id: case token_row.user_id {
+          Some(user_id) -> id.from_uuid(user_id)
+          None -> Id("")
+        },
+        token: token_row.token,
+        context: token_row.context,
+        sent_to: Some(token_row.sent_to),
+      ))
+
+    _ -> Error(CreateTokenError)
+  }
+}
+
+/// Generates a token that will be stored in a signed place,
+/// such as session or cookie. As they are signed, those
+/// tokens do not need to be hashed.
+///
+/// The reason why we store session tokens in the database, even
+/// though we already provides a session cookie, is because
+/// our default session cookies are not persisted, they are
+/// simply signed and potentially encrypted. This means they are
+/// valid indefinitely, unless you change the signing/encryption
+/// salt.
+///
+/// Therefore, storing them allows individual user
+/// sessions to be expired. The token system can also be extended
+/// to store additional data, such as the device used for logging in.
+/// You could then use this information to display all valid sessions
+/// and devices in the UI and allow users to explicitly expire any
+/// session they deem invalid.
+pub fn build_session_token(user: User) {
+  let token = crypto.strong_random_bytes(rand_size)
+  let str_token = bit_array.base64_url_encode(token, False)
+  #(
+    str_token,
+    Token(token:, context: "session", user_id: user.id, sent_to: None),
+  )
+}
+
+// Checks if the token is valid and returns its underlying lookup query.
+//
+// The query returns the user found by the token, if any.
+//
+// The token is valid if it matches the value in the database and it has
+// not expired (after @session_validity_in_days).
+pub fn verify_session_token(db: pog.Connection, str_token: String) {
+  let token =
+    str_token
+    |> bit_array.base64_url_decode()
+    |> result.unwrap(bit_array.from_string(""))
+
+  case sql.verify_session_token(db, token) {
+    Ok(pog.Returned(1, [user_row])) ->
+      Ok(User(
+        id: id.from_uuid(user_row.id),
+        email: user_row.email,
+        name: user_row.name,
+      ))
+
+    _ -> Error(SessionVerifyError)
+  }
+}
+
+// Builds a token and its hash to be delivered to the user's email.
+//
+// The non-hashed token is sent to the user email while the
+// hashed part is stored in the database. The original token cannot be reconstructed,
+// which means anyone with read-only access to the database cannot directly use
+// the token in the application to gain access. Furthermore, if the user changes
+// their email in the system, the tokens sent to the previous email are no longer
+// valid.
+//
+// Users can easily adapt the existing code to provide other types of delivery methods,
+// for example, by phone numbers.
+pub fn build_email_token(user: User, context: String) {
+  build_hashed_token(user.id, context, user.email)
+}
+
+fn build_hashed_token(
+  user_id: id.Id(users.User),
+  context: String,
+  sent_to: String,
+) {
+  let token = crypto.strong_random_bytes(rand_size)
+  let hashed_token = crypto.hash(crypto.Sha256, token)
+
+  #(
+    bit_array.base64_url_encode(token, False),
+    Token(
+      token: hashed_token,
+      context: context,
+      sent_to: Some(sent_to),
+      user_id: user_id,
+    ),
+  )
+}
+
+// Checks if the token is valid and returns its underlying lookup query.
+//
+// The query returns the user found by the token, if any.
+//
+// The given token is valid if it matches its hashed counterpart in the
+// database and the user email has not changed. This function also checks
+// if the token is being used within a certain period, depending on the
+// context. 
+pub fn verify_email_token(db: pog.Connection, token: String, context: String) {
+  case bit_array.base64_url_decode(token) {
+    Ok(decoded_token) -> {
+      let hashed_token = crypto.hash(crypto.Sha256, decoded_token)
+
+      case sql.verify_email_token(db, hashed_token, context) {
+        Ok(pog.Returned(1, [user_row])) ->
+          Ok(User(
+            id: id.from_uuid(user_row.id),
+            email: user_row.email,
+            name: user_row.name,
+          ))
+        _ -> Error(EmailVerifyError)
+      }
+    }
+
+    _ -> Error(EmailDecodeError)
+  }
+}

--- a/src/rsvp/models/tokens/sql/create_token.sql
+++ b/src/rsvp/models/tokens/sql/create_token.sql
@@ -1,0 +1,7 @@
+-- creates a token
+insert into
+    users_tokens(user_id, token, context, sent_to)
+values
+    ($1, $2, $3, $4)
+returning
+    *

--- a/src/rsvp/models/tokens/sql/get_token.sql
+++ b/src/rsvp/models/tokens/sql/get_token.sql
@@ -1,0 +1,7 @@
+-- gets a token
+select
+    *
+from
+    users_tokens
+where
+    token = $1

--- a/src/rsvp/models/tokens/sql/get_token_by_context.sql
+++ b/src/rsvp/models/tokens/sql/get_token_by_context.sql
@@ -1,0 +1,8 @@
+-- gets a token by token and context
+select
+    *
+from
+    users_tokens
+where
+    token = $1
+    and context = $2

--- a/src/rsvp/models/tokens/sql/verify_email_token.sql
+++ b/src/rsvp/models/tokens/sql/verify_email_token.sql
@@ -1,0 +1,13 @@
+-- verifies an email token by token and context
+select
+    u.*
+from 
+    users_tokens ut
+inner join 
+    users u 
+on 
+    ut.user_id = u.id
+where
+    ut.token = $1
+    and ut.context = $2
+    and ut.created_at > now() - interval '7 days'

--- a/src/rsvp/models/tokens/sql/verify_session_token.sql
+++ b/src/rsvp/models/tokens/sql/verify_session_token.sql
@@ -1,0 +1,13 @@
+-- verifies a session token
+select
+    u.*
+from
+    users_tokens ut
+inner join 
+    users u 
+on 
+    ut.user_id = u.id
+where
+    ut.token = $1
+    and ut.context = 'session'
+    and ut.created_at > now() - interval '3 months'

--- a/src/rsvp/models/users.gleam
+++ b/src/rsvp/models/users.gleam
@@ -1,0 +1,81 @@
+import pog
+import rsvp/models/id.{type Id}
+import rsvp/models/users/sql
+import wisp
+
+pub type User {
+  User(id: Id(User), email: String, name: String)
+}
+
+pub type UserError {
+  CreateUserError
+  GetUserError
+  UpdateUserError
+}
+
+pub fn create_user(db: pog.Connection, email email: String, name name: String) {
+  case sql.create_user(db, email, name) {
+    Ok(pog.Returned(1, [user_row])) ->
+      Ok(User(
+        id: id.from_uuid(user_row.id),
+        email: user_row.email,
+        name: user_row.name,
+      ))
+
+    _ -> {
+      wisp.log_error("Could not create user")
+      Error(CreateUserError)
+    }
+  }
+}
+
+pub fn get_user(db: pog.Connection, user_id: Id(User)) {
+  case sql.get_user_by_id(db, user_id |> id.to_uuid()) {
+    Ok(pog.Returned(1, [user_row])) ->
+      Ok(User(
+        id: id.from_uuid(user_row.id),
+        email: user_row.email,
+        name: user_row.name,
+      ))
+
+    _ -> {
+      wisp.log_error("Could not get user by id")
+      Error(GetUserError)
+    }
+  }
+}
+
+pub fn get_user_by_email(db: pog.Connection, email: String) {
+  case sql.get_user_by_email(db, email) {
+    Ok(pog.Returned(1, [user_row])) ->
+      Ok(User(
+        id: id.from_uuid(user_row.id),
+        email: user_row.email,
+        name: user_row.name,
+      ))
+
+    _ -> {
+      wisp.log_error("Could not get user by email")
+      Error(GetUserError)
+    }
+  }
+}
+
+pub fn update_user(db: pog.Connection, user: User) {
+  let user_id = user.id |> id.to_uuid()
+
+  case sql.update_user(db, user_id, user.name, user.email) {
+    Ok(pog.Returned(1, [user_row])) ->
+      // this is getting old, I need to go look further into Gleam's generics
+      Ok(User(
+        id: id.from_uuid(user_row.id),
+        email: user_row.email,
+        name: user_row.name,
+      ))
+
+    _ -> {
+      wisp.log_error("Could not update user")
+      Error(UpdateUserError)
+    }
+  }
+}

--- a/src/rsvp/models/users/sql/create_user.sql
+++ b/src/rsvp/models/users/sql/create_user.sql
@@ -1,0 +1,7 @@
+-- creates a user
+insert into
+    users(email, name)
+values
+    ($1, $2)
+returning
+    *

--- a/src/rsvp/models/users/sql/update_user.sql
+++ b/src/rsvp/models/users/sql/update_user.sql
@@ -1,0 +1,10 @@
+-- updates a user
+update
+    users
+set
+    name = $2,
+    email = $3
+where
+    id = $1
+returning
+    *

--- a/src/rsvp/pages/events.gleam
+++ b/src/rsvp/pages/events.gleam
@@ -1,0 +1,25 @@
+import gleam/http.{Get}
+import lustre/element/html
+import rsvp/context.{type Context}
+import rsvp/layouts
+import rsvp/web
+import wisp.{type Request}
+
+pub fn handle_request(req: Request, ctx: Context) {
+  use req, ctx <- web.require_auth(req, ctx)
+
+  let path = wisp.path_segments(req)
+  let method = req.method
+
+  case method, path {
+    Get, ["events"] -> render(req, ctx)
+    _, _ -> wisp.not_found()
+  }
+}
+
+pub fn render(req: Request, ctx: Context) {
+  [html.h1([], [html.text("Events")])]
+  |> layouts.nav_layout(req, ctx)
+  |> layouts.root_layout(ctx, "Events")
+  |> layouts.to_html_response()
+}

--- a/src/rsvp/pages/login.gleam
+++ b/src/rsvp/pages/login.gleam
@@ -1,0 +1,171 @@
+import gleam/http.{Get, Post}
+import gleam/list
+import gleam/result
+import gleam/uri
+import lustre/attribute
+import lustre/element/html
+import rsvp/components/core
+import rsvp/context.{type Context}
+import rsvp/htmx
+import rsvp/layouts
+import rsvp/models/auth
+import rsvp/web
+import valid/experimental as valid
+import wisp.{type Request}
+
+pub fn handle_request(req: Request, ctx: Context) {
+  use req, ctx <- web.require_anon(req, ctx)
+
+  let path = wisp.path_segments(req)
+  let method = req.method
+
+  case method, path {
+    Get, ["login"] -> render_login(req, ctx)
+    Post, ["login"] -> handle_submit(req, ctx)
+    Get, ["login", "instructions"] -> render_instructions(req, ctx)
+    _, _ -> wisp.not_found()
+  }
+}
+
+type LoginForm {
+  LoginForm(email: String, redirect: String, errors: List(String))
+}
+
+fn render_login(req: Request, ctx: Context) {
+  let defaults =
+    LoginForm(email: "", redirect: web.get_redirect(req), errors: [])
+
+  [html.article([], [login_form(defaults)])]
+  |> layouts.nav_layout(req, ctx)
+  |> layouts.root_layout(ctx, "Login - RSVP")
+  |> layouts.to_html_response()
+}
+
+fn login_form(form: LoginForm) {
+  let aria_invalid = case form.email, form.errors {
+    "", [] -> ""
+    _, [] -> "false"
+    _, _ -> "true"
+  }
+
+  html.form(
+    [
+      attribute.method("POST"),
+      attribute.action("/login"),
+      htmx.hx_post("/login"),
+      htmx.hx_swap("outerHTML"),
+      htmx.hx_target("this"),
+    ],
+    [
+      html.input([
+        attribute.type_("hidden"),
+        attribute.name("redirect"),
+        attribute.value(form.redirect),
+      ]),
+      html.input([
+        // how many times can we mark one field as email?
+        attribute.name("email"),
+        attribute.type_("email"),
+        attribute.value(form.email),
+        attribute.required(True),
+        attribute.placeholder("Email"),
+        attribute.aria_label("Email"),
+        attribute.aria_invalid(aria_invalid),
+      ]),
+      html.ul(
+        [],
+        form.errors
+          |> list.map(fn(err) { html.li([], [html.text(err)]) }),
+      ),
+      html.button([attribute.type_("submit")], [
+        core.icon("send", []),
+        html.text(" Send a login link"),
+      ]),
+    ],
+  )
+}
+
+fn handle_submit(req: Request, ctx: Context) {
+  use formdata <- wisp.require_form(req)
+
+  let redirect =
+    formdata.values
+    |> list.key_find("redirect")
+    |> result.unwrap("")
+    |> web.redirect_validator()
+
+  let input_email =
+    formdata.values
+    |> list.key_find("email")
+    |> result.unwrap("")
+
+  let #(email, errors) = email_validator(input_email)
+
+  case errors {
+    [] -> {
+      case auth.email_user_with_magic_link(ctx.db, email, redirect) {
+        Ok(_) ->
+          case htmx.is_htmx_request(req) {
+            True ->
+              instructions()
+              |> layouts.to_html_response()
+
+            False ->
+              wisp.redirect(
+                "/login/instructions?"
+                <> uri.query_to_string([#("email", email)]),
+              )
+          }
+
+        _ -> {
+          case htmx.is_htmx_request(req) {
+            True ->
+              LoginForm(email:, redirect:, errors: [
+                "Could not create user. Please try again later",
+              ])
+              |> login_form()
+              |> layouts.to_html_status(422)
+
+            False ->
+              // TODO: show errors somehow?
+              wisp.redirect(
+                "/login?" <> uri.query_to_string([#("r", redirect)]),
+              )
+          }
+        }
+      }
+    }
+    errors -> {
+      case htmx.is_htmx_request(req) {
+        True ->
+          LoginForm(email:, errors:, redirect:)
+          |> login_form()
+          |> layouts.to_html_status(422)
+
+        False ->
+          // TODO: show errors somehow?
+          wisp.redirect("/login?" <> uri.query_to_string([#("r", redirect)]))
+      }
+    }
+  }
+}
+
+fn instructions() {
+  html.div([], [
+    html.h1([], [core.icon("mail", []), html.text(" Link Sent")]),
+    html.p([], [html.text("Click the link in your email to log in.")]),
+  ])
+}
+
+fn render_instructions(req: Request, ctx: Context) {
+  [html.article([], [instructions()])]
+  |> layouts.nav_layout(req, ctx)
+  |> layouts.root_layout(ctx, "Login - RSVP")
+  |> layouts.to_html_response()
+}
+
+fn email_validator(input: String) {
+  // TODO: the validator here is rather simple. Maybe keep looking for a better one?
+  input
+  |> valid.string_is_email("Please enter a valid email")
+}

--- a/src/rsvp/pages/logout.gleam
+++ b/src/rsvp/pages/logout.gleam
@@ -1,0 +1,25 @@
+import gleam/http.{Delete, Get, Post}
+import rsvp/context.{type Context}
+import rsvp/htmx
+import rsvp/web
+import wisp.{type Request}
+
+pub fn handle_request(req: Request, ctx: Context) {
+  use req, _ctx <- web.require_auth(req, ctx)
+
+  // If you were really hardcore into correct http responses, you'd probably only
+  // allow delete here. However, I don't give a shit other than making sure that
+  // typical header-only requests like HEAD or OPTIONS aren't allowed.
+  case req.method {
+    Get -> logout(req)
+    Post -> logout(req)
+    Delete -> logout(req)
+    _ -> wisp.not_found()
+  }
+}
+
+fn logout(req: Request) {
+  // to log out we just expire the cookie and redirect to home
+  htmx.redirect("/", req)
+  |> wisp.set_cookie(req, web.get_session_cookie_name(), "", wisp.Signed, -1)
+}

--- a/src/rsvp/pages/token.gleam
+++ b/src/rsvp/pages/token.gleam
@@ -1,0 +1,152 @@
+import gleam/http.{Get, Post}
+import gleam/list
+import gleam/result
+import gleam/uri
+import lustre/attribute
+import lustre/element/html
+import rsvp/components/core
+import rsvp/context.{type Context}
+import rsvp/htmx
+import rsvp/layouts
+import rsvp/models/tokens
+import rsvp/web
+import wisp.{type Request}
+
+pub fn handle_request(req: Request, ctx: Context) {
+  use req, ctx <- web.require_anon(req, ctx)
+
+  let path = wisp.path_segments(req)
+  let method = req.method
+
+  case method, path {
+    Get, ["token", token] -> render_token(req, ctx, token)
+    Post, ["token"] -> handle_submit(req, ctx)
+    Get, ["token", ..] -> render_invalid(req, ctx)
+    _, _ -> wisp.not_found()
+  }
+}
+
+type TokenForm {
+  TokenForm(token: String, redirect: String, errors: List(String))
+}
+
+fn render_token(req: Request, ctx: Context, token: String) {
+  let defaults = TokenForm(token:, redirect: web.get_redirect(req), errors: [])
+
+  [html.article([], [token_form(defaults)])]
+  |> layouts.nav_layout(req, ctx)
+  |> layouts.root_layout(ctx, "Login - RSVP")
+  |> layouts.to_html_response()
+}
+
+fn token_form(form: TokenForm) {
+  html.form(
+    [
+      attribute.method("POST"),
+      attribute.action("/token"),
+      htmx.hx_post("/token"),
+      htmx.hx_swap("outerHTML"),
+      htmx.hx_target("this"),
+    ],
+    [
+      html.p([], [html.text("Welcome Back!")]),
+      html.input([
+        attribute.type_("hidden"),
+        attribute.name("redirect"),
+        attribute.value(form.redirect),
+      ]),
+      html.input([
+        attribute.type_("hidden"),
+        attribute.name("token"),
+        attribute.value(form.token),
+      ]),
+      html.ul(
+        [],
+        form.errors
+          |> list.map(fn(err) { html.li([], [html.text(err)]) }),
+      ),
+      html.button([attribute.type_("submit")], [
+        html.text("Continue "),
+        core.icon("log-in", []),
+      ]),
+    ],
+  )
+}
+
+fn handle_submit(req: Request, ctx: Context) {
+  use formdata <- wisp.require_form(req)
+
+  let redirect =
+    formdata.values
+    |> list.key_find("redirect")
+    |> result.unwrap("")
+    |> web.redirect_validator()
+
+  let token =
+    formdata.values
+    |> list.key_find("token")
+    |> result.unwrap("")
+
+  case tokens.verify_email_token(ctx.db, token, "login") {
+    Ok(user) -> {
+      // create a session token and set the cookie
+      let #(str_token, token) = tokens.build_session_token(user)
+
+      case tokens.create_token(ctx.db, token) {
+        Ok(_) -> {
+          redirect
+          |> htmx.redirect(req)
+          |> wisp.set_cookie(
+            req,
+            web.get_session_cookie_name(),
+            str_token,
+            wisp.Signed,
+            30 * 24 * 60 * 60,
+          )
+        }
+
+        _ -> {
+          wisp.log_error("Could not create session")
+          htmx.redirect("/", req)
+        }
+      }
+    }
+    _ -> {
+      case htmx.is_htmx_request(req) {
+        True ->
+          redirect
+          |> invalid()
+          |> layouts.to_html_status(422)
+
+        False ->
+          wisp.redirect("/token?" <> uri.query_to_string([#("r", redirect)]))
+      }
+    }
+  }
+}
+
+fn invalid(redirect: String) {
+  html.div([], [
+    html.p([], [html.text("The provided link was invalid or has expired.")]),
+    html.a(
+      [
+        attribute.role("button"),
+        attribute.href("/login?" <> uri.query_to_string([#("r", redirect)])),
+      ],
+      [html.text("Try Again "), core.icon("log-in", [])],
+    ),
+  ])
+}
+
+fn render_invalid(req: Request, ctx: Context) {
+  [
+    html.article([], [
+      req
+      |> web.get_redirect()
+      |> invalid(),
+    ]),
+  ]
+  |> layouts.nav_layout(req, ctx)
+  |> layouts.root_layout(ctx, "Login - RSVP")
+  |> layouts.to_html_response()
+}

--- a/src/rsvp/router.gleam
+++ b/src/rsvp/router.gleam
@@ -1,7 +1,11 @@
 import gleam/http.{Get}
 import gleam/string
 import rsvp/context.{type Context}
+import rsvp/pages/events
 import rsvp/pages/home
+import rsvp/pages/login
+import rsvp/pages/logout
+import rsvp/pages/token
 import rsvp/web
 import wisp.{type Response}
 
@@ -21,6 +25,10 @@ pub fn handle_request(req, ctx) {
 
   case method, path {
     Get, [] -> home.render(req, ctx)
+    _, ["login", ..] -> login.handle_request(req, ctx)
+    _, ["logout"] -> logout.handle_request(req, ctx)
+    _, ["events", ..] -> events.handle_request(req, ctx)
+    _, ["token", ..] -> token.handle_request(req, ctx)
     _, _ -> wisp.not_found()
   }
   |> wisp.set_header("Content-Security-Policy", content_security_policy)

--- a/src/rsvp/utils.gleam
+++ b/src/rsvp/utils.gleam
@@ -1,0 +1,21 @@
+// Might've just shat gold here.
+//
+// Since most of our request handlers need to return a Response, using the
+// `use ok_item <- result.try(something_producing_result())` syntax doesn't work 
+// out great because it returns an Error. So this is exactly that, but we take 
+// another function to map the error into the expected return type for the function.
+// 
+// This gives much nicer error handling since we handle it right next to the call
+// producing the error (like Go but not as fugly).
+//
+// Didn't see anything like this in the std lib but maybe I'm missing it.
+pub fn try_and_map_error(
+  result: Result(a, b),
+  map_error: fn(b) -> d,
+  next: fn(a) -> d,
+) {
+  case result {
+    Ok(value) -> next(value)
+    Error(err) -> map_error(err)
+  }
+}

--- a/src/rsvp/web.gleam
+++ b/src/rsvp/web.gleam
@@ -43,13 +43,11 @@ fn add_user_to_context(
   ctx: Context,
   handle_request: fn(Request, Context) -> Response,
 ) {
-  let token =
+  let user =
     req
     |> wisp.get_cookie(session_cookie_name, wisp.Signed)
     |> result.unwrap("")
-
-  let user =
-    tokens.verify_session_token(ctx.db, token)
+    |> tokens.verify_session_token(ctx.db, _)
     |> result.map(Some)
     |> result.unwrap(None)
 

--- a/src/rsvp/web.gleam
+++ b/src/rsvp/web.gleam
@@ -149,7 +149,10 @@ pub fn get_redirect(req: Request) {
 /// such as https://evil.com
 pub fn redirect_validator(input: String) {
   case input {
-    // any relative path
+    // scheme-relative paths are not valid
+    "//" <> _ -> "/events"
+
+    // any relative path is valid
     "/" <> _ -> input
 
     // otherwise just redirect to the events page

--- a/src/rsvp/web.gleam
+++ b/src/rsvp/web.gleam
@@ -43,16 +43,17 @@ fn add_user_to_context(
   ctx: Context,
   handle_request: fn(Request, Context) -> Response,
 ) {
-  let ctx = case wisp.get_cookie(req, session_cookie_name, wisp.Signed) {
-    Ok(token) -> {
-      case tokens.verify_session_token(ctx.db, token) {
-        Ok(user) -> Context(..ctx, user: Some(user))
+  let token =
+    req
+    |> wisp.get_cookie(session_cookie_name, wisp.Signed)
+    |> result.unwrap("")
 
-        _ -> ctx
-      }
-    }
-    _ -> ctx
-  }
+  let user =
+    tokens.verify_session_token(ctx.db, token)
+    |> result.map(Some)
+    |> result.unwrap(None)
+
+  let ctx = Context(..ctx, user:)
 
   handle_request(req, ctx)
 }


### PR DESCRIPTION
Some notes here:
- Not happy with the error handling so far. I have some ideas and will  try to get those in before merging.
- Could use a `/dev/mail` route like Phoenix so you can see mail without digging through the logs. Wrote a new issue for that in #14 
- I changed the first two migrations. Usually this is a big no-no, but  we don't have a production instance or even other devs yet so I'd rather have one file to reference for how I want to do tables rather  than having to dump that from `psql` or something.

resolves #11 